### PR TITLE
Use WithMethods to limit CORS HTTP methods

### DIFF
--- a/src/BlackSlope.Hosts.Api/Startup.cs
+++ b/src/BlackSlope.Hosts.Api/Startup.cs
@@ -85,7 +85,7 @@ namespace BlackSlope.Hosts.Api
                 options.AddPolicy("AllowSpecificOrigin",
                     builder => builder.AllowAnyOrigin()     // TODO: Replace with FE Service Host as appropriate to constrain clients
                         .AllowAnyHeader()
-                        .WithHeaders(new[] { "PUT", "POST", "OPTIONS", "GET", "DELETE" }));
+                        .WithMethods("PUT", "POST", "OPTIONS", "GET", "DELETE"));
             });
         }
 


### PR DESCRIPTION
WithHeaders is to limit accepted headers but was passed HTTP methods.  