### PR TITLE
Configure JSON serializer to do string to enum conversions for MVC service

### DIFF
--- a/src/BlackSlope.Hosts.Api.Common/Extensions/BlackSlopeServiceCollectionExtensions.cs
+++ b/src/BlackSlope.Hosts.Api.Common/Extensions/BlackSlopeServiceCollectionExtensions.cs
@@ -2,12 +2,21 @@
 using System.Collections.Generic;
 using System.IO;
 using BlackSlope.Hosts.Api.Common.Configurtion;
+using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Swashbuckle.AspNetCore.Swagger;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
     public static class BlackSlopeServiceCollectionExtensions
     {
+        /// <summary>
+        /// Adds Swagger service to the IServiceCollection and configure it 
+        /// </summary>
+        /// <param name="services"></param>
+        /// <param name="swaggerConfig"></param>
+        /// <returns></returns>
         public static IServiceCollection AddSwagger(this IServiceCollection services, SwaggerConfig swaggerConfig)
         {
             return services.AddSwaggerGen(c =>
@@ -32,6 +41,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
                 c.IncludeXmlComments(xmlPath);
             });
+        }
+
+        /// <summary>
+        /// Adds MVC service to the IServiceCollection and configure json serializer behavior 
+        /// </summary>
+        /// <param name="services"></param>
+        /// <returns></returns>
+        public static IMvcBuilder AddMvcService(this IServiceCollection services)
+        {
+            return services.AddMvc()
+                .SetCompatibilityVersion(CompatibilityVersion.Version_2_2)
+                .AddJsonOptions(options =>
+                {
+                    options.SerializerSettings.Converters.Add(new StringEnumConverter());
+                    options.SerializerSettings.NullValueHandling = NullValueHandling.Ignore;
+                });
         }
     }
 }

--- a/src/BlackSlope.Hosts.Api/Startup.cs
+++ b/src/BlackSlope.Hosts.Api/Startup.cs
@@ -10,7 +10,6 @@ using BlackSlope.Hosts.Api.Operations.Movies.Validators.Extensions;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -30,14 +29,14 @@ namespace BlackSlope.Hosts.Api
         public void ConfigureServices(IServiceCollection services)
         {
 
-            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
+            services.AddMvcService();
             ApplicationConfiguration(services);
 
             services.AddSwagger(HostConfig.Swagger);
             CorsConfiguration(services);
             AuthenticationConfiguration(services);
-                        
-            services.AddSingleton<IMapper>(GenerateMapperConfiguration());
+
+            services.AddSingleton(GenerateMapperConfiguration());
             services.AddTransient<ICorrelationIdRequestReader, CorrelationIdHeaderService>();
             services.AddTransient<ICorrelationIdResponseWriter, CorrelationIdHeaderService>();
             services.AddScoped<ICurrentCorrelationIdService, CurrentCorrelationIdService>();


### PR DESCRIPTION
instead of using numbers for enum it will use the equivalent string in request and response.
Also pushed this to common to be shared.