### PR TITLE
Set validation custom states as ApiError codes

### DIFF
--- a/src/BlackSlope.Hosts.Api.Common/Validators/BlackslopeValidator.cs
+++ b/src/BlackSlope.Hosts.Api.Common/Validators/BlackslopeValidator.cs
@@ -1,4 +1,5 @@
-﻿using FluentValidation;
+﻿using System;
+using FluentValidation;
 using System.Linq;
 using FluentValidation.Results;
 using BlackSlope.Hosts.Api.Common.ViewModels;
@@ -28,14 +29,28 @@ namespace BlackSlope.Hosts.Api.Common.Validators
         {
             if (!result.IsValid)
             {
-                var errors = result.Errors.Select(e => new ApiError
-                {
-                    Code = (int)ApiHttpStatusCode.BadRequest,
-                    Message = e.ErrorMessage
-                }).ToList();
-
+                var errors = result.Errors.Select(CreateApiError).ToList();
                 throw new ApiException(ApiHttpStatusCode.BadRequest, instance, errors);
             }
+        }
+
+        private static ApiError CreateApiError(ValidationFailure validationFailure)
+        {
+            int errorCode;
+            if (validationFailure.CustomState is Enum)
+            {
+                errorCode = (int)validationFailure.CustomState;
+            }
+            else
+            {
+                errorCode = (int)ApiHttpStatusCode.BadRequest;
+            }
+
+            return new ApiError
+            {
+                Code = errorCode,
+                Message = validationFailure.ErrorMessage
+            };
         }
     }
 }


### PR DESCRIPTION
ApiError codes for FluentValidation failures are set to the custom state Enum, if it exists.