### PR TITLE
Fix spelling; Cleanup some usings

### DIFF
--- a/src/BlackSlope.Api.Common/Configuration/ApplicationInsightsConfig.cs
+++ b/src/BlackSlope.Api.Common/Configuration/ApplicationInsightsConfig.cs
@@ -1,4 +1,4 @@
-﻿namespace BlackSlope.Api.Common.Configurtion
+﻿namespace BlackSlope.Api.Common.Configuration
 {
     public class ApplicationInsightsConfig
     {

--- a/src/BlackSlope.Api.Common/Configuration/AzureAdConfig.cs
+++ b/src/BlackSlope.Api.Common/Configuration/AzureAdConfig.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace BlackSlope.Api.Common.Configurtion
+﻿namespace BlackSlope.Api.Common.Configuration
 {
     public class AzureAdConfig
     {

--- a/src/BlackSlope.Api.Common/Configuration/HostConfig.cs
+++ b/src/BlackSlope.Api.Common/Configuration/HostConfig.cs
@@ -1,4 +1,4 @@
-﻿namespace BlackSlope.Api.Common.Configurtion
+﻿namespace BlackSlope.Api.Common.Configuration
 {
     public class HostConfig
     {

--- a/src/BlackSlope.Api.Common/Configuration/SerilogConfig.cs
+++ b/src/BlackSlope.Api.Common/Configuration/SerilogConfig.cs
@@ -1,4 +1,4 @@
-﻿namespace BlackSlope.Api.Common.Configurtion
+﻿namespace BlackSlope.Api.Common.Configuration
 {
     public class SerilogConfig
     {

--- a/src/BlackSlope.Api.Common/Configuration/SwaggerConfig.cs
+++ b/src/BlackSlope.Api.Common/Configuration/SwaggerConfig.cs
@@ -1,4 +1,4 @@
-﻿namespace BlackSlope.Api.Common.Configurtion
+﻿namespace BlackSlope.Api.Common.Configuration
 {
     public class SwaggerConfig
     {

--- a/src/BlackSlope.Api.Common/Extensions/BlackSlopeBuilderExtensions.cs
+++ b/src/BlackSlope.Api.Common/Extensions/BlackSlopeBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿using BlackSlope.Api.Common.Configurtion;
+﻿using BlackSlope.Api.Common.Configuration;
 using Microsoft.AspNetCore.Builder;
 
 namespace BlackSlope.Api.Common.Extensions

--- a/src/BlackSlope.Api.Common/Extensions/BlackSlopeHostBuilderExtenstions.cs
+++ b/src/BlackSlope.Api.Common/Extensions/BlackSlopeHostBuilderExtenstions.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using BlackSlope.Api.Common.Configurtion;
+using BlackSlope.Api.Common.Configuration;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;

--- a/src/BlackSlope.Api.Common/Extensions/BlackSlopeServiceCollectionExtensions.cs
+++ b/src/BlackSlope.Api.Common/Extensions/BlackSlopeServiceCollectionExtensions.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using AutoMapper;
-using BlackSlope.Api.Common.Configurtion;
+using BlackSlope.Api.Common.Configuration;
 using BlackSlope.Api.Common.Swagger;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;

--- a/src/BlackSlope.Api/Startup.cs
+++ b/src/BlackSlope.Api/Startup.cs
@@ -1,6 +1,6 @@
 ﻿using System.IO.Abstractions;
 using System.Reflection;
-using BlackSlope.Api.Common.Configurtion;
+using BlackSlope.Api.Common.Configuration;
 using BlackSlope.Api.Common.Extensions;
 using BlackSlope.Api.Common.Middleware.Correlation;
 using BlackSlope.Api.Common.Middleware.ExceptionHandling;


### PR DESCRIPTION
`Blackslope.Api.Common.Configurtion` namespace was misspelled.