### PR TITLE
Patched swagger gen to output in OAS3

### DIFF
--- a/src/BlackSlope.Api.Common/BlackSlope.Api.Common.csproj
+++ b/src/BlackSlope.Api.Common/BlackSlope.Api.Common.csproj
@@ -40,9 +40,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.5.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.5.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.5.1" />
     <PackageReference Include="System.IO.Abstractions" Version="9.0.4" />
   </ItemGroup>
 

--- a/src/BlackSlope.Api.Common/Extensions/BlackSlopeBuilderExtensions.cs
+++ b/src/BlackSlope.Api.Common/Extensions/BlackSlopeBuilderExtensions.cs
@@ -11,7 +11,6 @@ namespace BlackSlope.Api.Common.Extensions
         {
             app.UseSwagger(c =>
             {
-                c.SerializeAsV2 = false; // NOTE: Will serialize in latest OpenAPI version
                 c.PreSerializeFilters.Add((swagger, httpReq) => swagger.Servers = new List<OpenApiServer> { new OpenApiServer { Url = $"{httpReq.Scheme}://{httpReq.Host.Value}" } });
             });
 

--- a/src/BlackSlope.Api.Common/Extensions/BlackSlopeBuilderExtensions.cs
+++ b/src/BlackSlope.Api.Common/Extensions/BlackSlopeBuilderExtensions.cs
@@ -11,7 +11,7 @@ namespace BlackSlope.Api.Common.Extensions
         {
             app.UseSwagger(c =>
             {
-                c.SerializeAsV2 = true;
+                c.SerializeAsV2 = false; // NOTE: Will serialize in latest OpenAPI version
                 c.PreSerializeFilters.Add((swagger, httpReq) => swagger.Servers = new List<OpenApiServer> { new OpenApiServer { Url = $"{httpReq.Scheme}://{httpReq.Host.Value}" } });
             });
 

--- a/src/BlackSlope.Api.Common/Extensions/BlackSlopeServiceCollectionExtensions.cs
+++ b/src/BlackSlope.Api.Common/Extensions/BlackSlopeServiceCollectionExtensions.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         private static void AddSecurityDefinition(SwaggerGenOptions options) =>
-            options.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme()
+            options.AddSecurityDefinition("oauth2", new OpenApiSecurityScheme()
             {
                 Name = "Authorization",
                 In = ParameterLocation.Header,

--- a/src/BlackSlope.Api/BlackSlope.Api.csproj
+++ b/src/BlackSlope.Api/BlackSlope.Api.csproj
@@ -28,19 +28,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="8.0.0" />
+    <PackageReference Include="AutoMapper" Version="8.1.1" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="8.6.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.2">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="3.1.2" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="3.1.5" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
* Patched swagger gen in Blackslope from OpenAPI v2 to v3.0.1.
  * This is now in GA for Azure API Management and should be kosher.
* Minor nuget bumps too.

No major updates are needed for Swagger gen beyond a small rename patch between our `SecurityScheme` and `Security` objects. Before they could be named w/e, but going forward they must have matching names.

[Version 2.0](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#securityRequirementObject)
vs.
[Version 3.0](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#securityRequirementObject)