### PR TITLE
Fixed validation error mismatch

### DIFF
--- a/src/BlackSlope.Api.Tests/OperationsTests/MoviesTests/ValidatorsTests/CreateMovieViewModelValidatorShould.cs
+++ b/src/BlackSlope.Api.Tests/OperationsTests/MoviesTests/ValidatorsTests/CreateMovieViewModelValidatorShould.cs
@@ -1,4 +1,5 @@
 ﻿using AutoFixture;
+using BlackSlope.Api.Operations.Movies.Enumerators;
 using BlackSlope.Api.Operations.Movies.Validators;
 using BlackSlope.Api.Operations.Movies.ViewModels;
 using BlackSlope.Services.Movies;
@@ -25,28 +26,40 @@ namespace BlackSlope.Api.Tests.OperationsTests.MoviesTests.ValidatorsTests
         public void Fail_when_title_is_null()
         {
             _modelViewModel.Title = null;
-            _movieViewModelValidator.ShouldHaveValidationErrorFor(x => x.Title, _modelViewModel);
+            var failures = _movieViewModelValidator
+                .ShouldHaveValidationErrorFor(x => x.Title, _modelViewModel)
+                .When(failure => MovieErrorCode.EmptyOrNullMovieTitle.Equals(failure.CustomState));
         }
 
         [Fact]
         public void Fail_when_description_is_null()
         {
             _modelViewModel.Description = null;
-            _movieViewModelValidator.ShouldHaveValidationErrorFor(x => x.Description, _modelViewModel);
+            _movieViewModelValidator
+                .ShouldHaveValidationErrorFor(x => x.Description, _modelViewModel)
+                .When(failure => MovieErrorCode.EmptyOrNullMovieDescription.Equals(failure.CustomState));
         }
 
-        [Fact]
-        public void Fail_when_title_is_not_between_2_and_50_characters()
+        [Theory]
+        [InlineData("d")]
+        [InlineData("A great movie title that is very thrilling but sadly too long.")]
+        public void Fail_when_title_is_not_between_2_and_50_characters(string title)
         {
-            _modelViewModel.Title = "2";
-            _movieViewModelValidator.ShouldHaveValidationErrorFor(x => x.Title.Length, _modelViewModel);
+            _modelViewModel.Title = title;
+            _movieViewModelValidator
+                .ShouldHaveValidationErrorFor(x => x.Title.Length, _modelViewModel)
+                .When(failure => MovieErrorCode.TitleNotBetween2and50Characters.Equals(failure.CustomState));
         }
 
-        [Fact]
-        public void Fail_when_description_is_not_between_2_and_50_characters()
+        [Theory]
+        [InlineData("d")]
+        [InlineData("A great movie description that is very descriptive but sadly too long.")]
+        public void Fail_when_description_is_not_between_2_and_50_characters(string description)
         {
-            _modelViewModel.Description = "d";
-            _movieViewModelValidator.ShouldHaveValidationErrorFor(x => x.Description.Length, _modelViewModel);
+            _modelViewModel.Description = description;
+            _movieViewModelValidator
+                .ShouldHaveValidationErrorFor(x => x.Description.Length, _modelViewModel)
+                .When(failure => MovieErrorCode.DescriptionNotBetween2and50Characters.Equals(failure.CustomState));
         }
 
         [Fact]

--- a/src/BlackSlope.Api.Tests/OperationsTests/MoviesTests/ValidatorsTests/UpdateMovieViewModelValidatorShould.cs
+++ b/src/BlackSlope.Api.Tests/OperationsTests/MoviesTests/ValidatorsTests/UpdateMovieViewModelValidatorShould.cs
@@ -1,4 +1,5 @@
 ﻿using AutoFixture;
+using BlackSlope.Api.Operations.Movies.Enumerators;
 using BlackSlope.Api.Operations.Movies.Validators;
 using BlackSlope.Api.Operations.Movies.ViewModels;
 using BlackSlope.Services.Movies;
@@ -25,35 +26,47 @@ namespace BlackSlope.Api.Tests.OperationsTests.MoviesTests.ValidatorsTests
         public void Fail_when_title_is_null()
         {
             _modelViewModel.Title = null;
-            _movieViewModelValidator.ShouldHaveValidationErrorFor(x => x.Title, _modelViewModel);
+            _movieViewModelValidator
+                .ShouldHaveValidationErrorFor(x => x.Title, _modelViewModel)
+                .When(failure => MovieErrorCode.EmptyOrNullMovieTitle.Equals(failure.CustomState)); ;
         }
 
         [Fact]
         public void Fail_when_description_is_null()
         {
             _modelViewModel.Description = null;
-            _movieViewModelValidator.ShouldHaveValidationErrorFor(x => x.Description, _modelViewModel);
+            _movieViewModelValidator
+                .ShouldHaveValidationErrorFor(x => x.Description, _modelViewModel)
+                .When(failure => MovieErrorCode.EmptyOrNullMovieDescription.Equals(failure.CustomState));
         }
 
-        [Fact]
-        public void Fail_when_title_is_not_between_2_and_50_characters()
+        [Theory]
+        [InlineData("d")]
+        [InlineData("A great movie title that is very thrilling but sadly too long.")]
+        public void Fail_when_title_is_not_between_2_and_50_characters(string title)
         {
-            _modelViewModel.Title = "2";
-            _movieViewModelValidator.ShouldHaveValidationErrorFor(x => x.Title.Length, _modelViewModel);
+            _modelViewModel.Title = title;
+            _movieViewModelValidator
+                .ShouldHaveValidationErrorFor(x => x.Title.Length, _modelViewModel)
+                .When(failure => MovieErrorCode.TitleNotBetween2and50Characters.Equals(failure.CustomState));
         }
 
-        [Fact]
-        public void Fail_when_description_is_not_between_2_and_50_characters()
+        [Theory]
+        [InlineData("d")]
+        [InlineData("A great movie description that is very descriptive but sadly too long.")]
+        public void Fail_when_description_is_not_between_2_and_50_characters(string description)
         {
-            _modelViewModel.Description = "d";
-            _movieViewModelValidator.ShouldHaveValidationErrorFor(x => x.Description.Length, _modelViewModel);
+            _modelViewModel.Description = description;
+            _movieViewModelValidator
+                .ShouldHaveValidationErrorFor(x => x.Description.Length, _modelViewModel)
+                .When(failure => MovieErrorCode.DescriptionNotBetween2and50Characters.Equals(failure.CustomState));
         }
 
         [Fact]
         public void Pass_when_title_is_between_2_and_50_characters()
         {
             _modelViewModel.Title = "the post";
-            _movieViewModelValidator.ShouldNotHaveValidationErrorFor(x => x.Title.Length, _modelViewModel);
+            _movieViewModelValidator.ShouldNotHaveValidationErrorFor(x => x.Title, _modelViewModel);
         }
 
         [Fact]
@@ -62,6 +75,5 @@ namespace BlackSlope.Api.Tests.OperationsTests.MoviesTests.ValidatorsTests
             _modelViewModel.Description = "Great movie";
             _movieViewModelValidator.ShouldNotHaveValidationErrorFor(x => x.Description, _modelViewModel);
         }
-
     }
 }

--- a/src/BlackSlope.Api/Operations/Movies/Validators/CreateMovieViewModelValidatorCollection.cs
+++ b/src/BlackSlope.Api/Operations/Movies/Validators/CreateMovieViewModelValidatorCollection.cs
@@ -25,7 +25,7 @@ namespace BlackSlope.Api.Operations.Movies.Validators
                 .WithState(x => MovieErrorCode.EmptyOrNullMovieDescription)
                 .DependentRules(() =>
                     RuleFor(x => x.Description.Length)
-                        .InclusiveBetween(2, 50).WithState(x => MovieErrorCode.TitleNotBetween2and50Characters));
+                        .InclusiveBetween(2, 50).WithState(x => MovieErrorCode.DescriptionNotBetween2and50Characters));
         }
     }
 }

--- a/src/BlackSlope.Api/Operations/Movies/Validators/UpdateMovieViewModelValidatorCollection.cs
+++ b/src/BlackSlope.Api/Operations/Movies/Validators/UpdateMovieViewModelValidatorCollection.cs
@@ -20,7 +20,7 @@ namespace BlackSlope.Api.Operations.Movies.Validators
                 .WithState(x => MovieErrorCode.EmptyOrNullMovieDescription)
                 .DependentRules(() =>
                     RuleFor(x => x.Description.Length)
-                        .InclusiveBetween(2, 50).WithState(x => MovieErrorCode.TitleNotBetween2and50Characters));
+                        .InclusiveBetween(2, 50).WithState(x => MovieErrorCode.DescriptionNotBetween2and50Characters));
         }
     }
 }


### PR DESCRIPTION
# Problem
When attempting to create or update a movie, if the **description** field is invalid, the error message explains that the **title** field is invalid.

# Solution
- Validator now makes correct use of `MovieErrorCode.DescriptionNotBetween2and50Characters`.
- Enhanced tests to also cover the expected custom state that is used to determine the type of error.
- Enhanced tests to cover more out of range scenarios.

## Reviewer Note
When testing the `ValidationFailure` `CustomState` I would have loved to make use of FluentValidation's `WithCustomState()` test helper extension but the function does not seem to play well with enum values.