### PR TITLE
feature/update-nuget-packages

### DIFF
--- a/src/BlackSlope.Api.Common.Tests/BlackSlope.Api.Common.Tests.csproj
+++ b/src/BlackSlope.Api.Common.Tests/BlackSlope.Api.Common.Tests.csproj
@@ -7,10 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BlackSlope.Api.Common.Tests/VersioningTests/VersionJsonConverterTests.cs
+++ b/src/BlackSlope.Api.Common.Tests/VersioningTests/VersionJsonConverterTests.cs
@@ -28,13 +28,11 @@ namespace BlackSlope.Api.Common.Tests.VersioningTests
             var stubJson = "{\"version\": \"1.0\"}";
             var seq = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes(stubJson));
             var jsonReader = new Utf8JsonReader(seq);
-
-
             try
             {
                 converter.Read(ref jsonReader, typeof(Version), null);
             }
-            catch(JsonException ex)
+            catch (JsonException)
             {
                 Assert.True(true);
                 return;
@@ -49,12 +47,11 @@ namespace BlackSlope.Api.Common.Tests.VersioningTests
             var stubJson = "{}";
             var jsonReader = SeedReader(stubJson);
             var converter = new VersionJsonConverter();
-
             try
             {
                 converter.Read(ref jsonReader, typeof(Version), null);
             }
-            catch (JsonException ex)
+            catch (JsonException)
             {
                 Assert.True(true);
                 return;
@@ -68,12 +65,11 @@ namespace BlackSlope.Api.Common.Tests.VersioningTests
         {
             var stubJson = "{\"version\": \"1.0\", \"failure\": 123}";
             var jsonReader = SeedReader(stubJson);
-
             try
             {
                 converter.Read(ref jsonReader, typeof(Version), null);
             }
-            catch (JsonException ex)
+            catch (JsonException)
             {
                 Assert.True(true);
                 return;

--- a/src/BlackSlope.Api.Common/BlackSlope.Api.Common.csproj
+++ b/src/BlackSlope.Api.Common/BlackSlope.Api.Common.csproj
@@ -23,26 +23,26 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="8.0.0" />
-    <PackageReference Include="FluentValidation" Version="8.6.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="AutoMapper" Version="10.1.1" />
+    <PackageReference Include="FluentValidation" Version="9.5.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.13" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.5.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.5.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.5.1" />
-    <PackageReference Include="System.IO.Abstractions" Version="9.0.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.1.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.1.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.1.1" />
+    <PackageReference Include="System.IO.Abstractions" Version="13.2.28" />
   </ItemGroup>
 
 </Project>

--- a/src/BlackSlope.Api.Common/Extensions/BlackSlopeHostBuilderExtensions.cs
+++ b/src/BlackSlope.Api.Common/Extensions/BlackSlopeHostBuilderExtensions.cs
@@ -53,7 +53,7 @@ namespace BlackSlope.Api.Common.Extensions
         {
             if (serilogConfig.WriteToConsole)
             {
-                config.WriteTo.ColoredConsole();
+                config.WriteTo.Console();
             }
         }
 

--- a/src/BlackSlope.Api.Common/Extensions/BlackSlopeServiceCollectionExtensions.cs
+++ b/src/BlackSlope.Api.Common/Extensions/BlackSlopeServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using System.Text.Json.Serialization;
 using AutoMapper;
 using BlackSlope.Api.Common.Configuration;
@@ -72,20 +73,21 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Add AutoMapper service to the Service Collection and configure it assemblies
         /// </summary>
         /// <param name="services"></param>
-        /// <param name="assemblyNamesToScan"></param>
+        /// <param name="assemblyProfilesToScan"></param>
         /// <returns></returns>
-        public static IServiceCollection AddAutoMapper(this IServiceCollection services, IEnumerable<string> assemblyNamesToScan)
+        public static IServiceCollection AddAutoMapper(this IServiceCollection services, IEnumerable<Assembly> assemblyProfilesToScan)
         {
-            services.TryAddSingleton(GenerateMapperConfiguration(assemblyNamesToScan));
+            services.TryAddSingleton(GenerateMapperConfiguration(assemblyProfilesToScan));
             return services;
         }
 
-        private static IMapper GenerateMapperConfiguration(IEnumerable<string> assemblyNamesToScan)
+        private static IMapper GenerateMapperConfiguration(IEnumerable<Assembly> assemblyProfilesToScan)
         {
             var config = new MapperConfiguration(cfg =>
             {
-                cfg.AddProfiles(assemblyNamesToScan);
+                cfg.AddMaps(assemblyProfilesToScan);
             });
+
             return config.CreateMapper();
         }
 

--- a/src/BlackSlope.Api.Common/Swagger/DocumentFilterAddHealth.cs
+++ b/src/BlackSlope.Api.Common/Swagger/DocumentFilterAddHealth.cs
@@ -13,7 +13,7 @@ namespace BlackSlope.Api.Common.Swagger
             swaggerDoc.Paths.Add("/health", HealthPathItem());
         }
 
-        private OpenApiPathItem HealthPathItem()
+        private static OpenApiPathItem HealthPathItem()
         {
             var pathItem = new OpenApiPathItem();
             pathItem.AddOperation(OperationType.Get, new OpenApiOperation

--- a/src/BlackSlope.Api.Common/Versioning/VersionJsonConverter.cs
+++ b/src/BlackSlope.Api.Common/Versioning/VersionJsonConverter.cs
@@ -49,7 +49,7 @@ namespace BlackSlope.Api.Common.Versioning
             writer.WritePropertyName(_buildVersionName);
             writer.WriteStringValue(value?.BuildVersion);
             writer.WriteEndObject();
-            
+
             writer.Flush();
         }
     }

--- a/src/BlackSlope.Api.Tests/BlackSlope.Api.Tests.csproj
+++ b/src/BlackSlope.Api.Tests/BlackSlope.Api.Tests.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="AutoFixture" Version="4.15.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/BlackSlope.Api/BlackSlope.Api.csproj
+++ b/src/BlackSlope.Api/BlackSlope.Api.csproj
@@ -28,18 +28,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="8.1.1" />
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="8.6.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+    <PackageReference Include="AutoMapper" Version="10.1.1" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="9.5.3" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.5">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="3.1.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="3.1.13" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/src/BlackSlope.Api/Repositories/Movies/Context/MovieContext.cs
+++ b/src/BlackSlope.Api/Repositories/Movies/Context/MovieContext.cs
@@ -32,7 +32,7 @@ namespace BlackSlope.Repositories.Movies.Context
             modelBuilder.Entity<MovieDtoModel>(entity =>
             {
                 entity.HasIndex(e => e.Title)
-                    .HasName("IX_Movies_Title");
+                    .HasDatabaseName("IX_Movies_Title");
             });
 
             modelBuilder.Seed();

--- a/src/BlackSlope.Api/Startup.cs
+++ b/src/BlackSlope.Api/Startup.cs
@@ -36,13 +36,13 @@ namespace BlackSlope.Api
 
             services.AddSwagger(HostConfig.Swagger);
             services.AddAzureAd(HostConfig.AzureAd);
-            services.AddAutoMapper(GetAssemblyNamesToScanForMapperProfiles());
+            services.AddAutoMapper(GetAssembliesToScanForMapperProfiles());
             services.AddCorrelation();
             services.AddTransient<IFileSystem, FileSystem>();
 
             // NOTE: Pick one of the below versioning services
             services.AddTransient<IVersionService, AssemblyVersionService>(); // For Version parsing via Assembly ref
-            //services.AddTransient<IVersionService, JsonVersionService>();   // For Version parsing via JSON
+            // services.AddTransient<IVersionService, JsonVersionService>();   // For Version parsing via JSON
 
             services.AddHealthChecksService();
 
@@ -96,8 +96,8 @@ namespace BlackSlope.Api
         }
 
         // make a list of projects in the solution which must be scanned for mapper profiles
-        private static IEnumerable<string> GetAssemblyNamesToScanForMapperProfiles() =>
-            new string[] { Assembly.GetExecutingAssembly().GetName().Name };
+        private static IEnumerable<Assembly> GetAssembliesToScanForMapperProfiles() =>
+            new Assembly[] { Assembly.GetExecutingAssembly() };
 
         private void ApplicationConfiguration(IServiceCollection services)
         {

--- a/src/BlackSlope.Hosts.Console/AuthenticationToken.cs
+++ b/src/BlackSlope.Hosts.Console/AuthenticationToken.cs
@@ -9,7 +9,7 @@ namespace BlackSlope.Hosts.ConsoleApp
     {
         public static async Task GetAuthTokenAsync()
         {
-            Console.WriteLine("Welcome to the BlackSlop.NET Console");
+            Console.WriteLine("Welcome to the BlackSlope.NET Console");
             Console.WriteLine("");
 
             Console.Write("ClientId: ");

--- a/src/BlackSlope.Hosts.Console/BlackSlope.Hosts.ConsoleApp.csproj
+++ b/src/BlackSlope.Hosts.Console/BlackSlope.Hosts.ConsoleApp.csproj
@@ -9,17 +9,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="8.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="AutoMapper" Version="10.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.5.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.13" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.13" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.13" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.13" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
   </ItemGroup>
 
 </Project>

--- a/src/BlackSlope.NET.sln
+++ b/src/BlackSlope.NET.sln
@@ -21,21 +21,17 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Scripts", "Scripts", "{551F
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{87D53136-CBF4-4A45-814C-3E5B04965959}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A2744270-EAA9-48AD-A288-0E45E23EB125}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docker", "Docker", "{A2744270-EAA9-48AD-A288-0E45E23EB125}"
 	ProjectSection(SolutionItems) = preProject
+		.dockerignore = .dockerignore
 		..\.editorconfig = ..\.editorconfig
+		docker-compose.yml = docker-compose.yml
+		Dockerfile = Dockerfile
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tools", "Tools", "{CBFD1F3D-2E8C-439A-BA65-99E109049C4B}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RenameUtility", "RenameUtility\RenameUtility\RenameUtility.csproj", "{C059E3FE-FE94-4FBC-B5D8-399D310EFB40}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docker", "Docker", "{C1DC83C0-985C-455C-9891-0C3A0BF39280}"
-	ProjectSection(SolutionItems) = preProject
-		..\docker-container-run.sh = ..\docker-container-run.sh
-		..\docker-image-build.sh = ..\docker-image-build.sh
-		..\Dockerfile = ..\Dockerfile
-	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Api", "Api", "{0291711F-2A49-4DFA-A39B-42AEA2011A1E}"
 EndProject
@@ -47,7 +43,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlackSlope.Api.Common", "Bl
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlackSlope.Api.Tests", "BlackSlope.Api.Tests\BlackSlope.Api.Tests.csproj", "{8904D58B-A6E1-45F7-9B2B-1AB71C09FBDC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlackSlope.Api.Common.Tests", "BlackSlope.Api.Common.Tests\BlackSlope.Api.Common.Tests.csproj", "{C9AE747A-CF32-4945-AE0B-F053937DEC9C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlackSlope.Api.Common.Tests", "BlackSlope.Api.Common.Tests\BlackSlope.Api.Common.Tests.csproj", "{C9AE747A-CF32-4945-AE0B-F053937DEC9C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,12 +1,12 @@
 # Build the application
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
+FROM mcr.microsoft.com/dotnet/sdk:3.1 AS build
 COPY . .
 WORKDIR /BlackSlope.Api
 RUN dotnet restore
 RUN dotnet publish --no-restore -c Release -o /app
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
+FROM mcr.microsoft.com/dotnet/aspnet:3.1
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -1,8 +1,8 @@
-version: '3.5'
+version: '3.8'
 services: 
   db: 
     container_name: db
-    image: mcr.microsoft.com/mssql/server:2017-latest
+    image: mcr.microsoft.com/mssql/server:2019-latest
     environment:
       SA_PASSWORD: "YourStrong!Passw0rd"
       ACCEPT_EULA: "Y"


### PR DESCRIPTION
  **NOTE**: These changes should be 1:1 with our `master-5.x` branch per the last PR.
  https://github.com/SlalomBuild/blackslope.net/pull/39

- Updated MSFT Nuget packages to latest versions of 3.x release stream
- deprecated FxCop in favor of new Analyzer package
- Docker logic properly stashed
- Docker logic targets latest MSFT resouces
- Updated all 3rd party pkgs to latest
  - Automapper config tweaked to use Assembly objs over strings in scan setup
  - Serilog Color Console pkg deprecated/replaced